### PR TITLE
Support quantity as the name of a number

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,27 +34,53 @@ To print a label, you need to set up IFTTT to trigger a Webhook action in respon
 1. Set the URL to the `Function URL` parameter printed during deployment. It will be something like, `https://us-central1-myproject.cloudfunctions.net/printBatch`, where `myproject` will be the name of your Firebase project.
 1. Set the method to `POST`.
 1. Set the content type to `application/json`.
+1. Under "Additional Headers" enter:
+    ```
+    Authorization: AUTH_KEY
+    ```
+    Where `AUTH_KEY` is the authentication key you set earlier.
 1. Set the body to:
     ```json
-    { "authentication": "AUTH_KEY", "items": [ {"body": "Text to print", "qty": 1} ] }
+    { "items": [ {"body": "Text to print", "qty": 1} ] }
     ```
-    Where `AUTH_KEY` is the authentication key you set earlier. The `body` and `qty` may be ingredients from your trigger.
+    The `body` and `qty` may be ingredients from your trigger.
 1. Click "Update action" to save your applet.
 1. Try it out!
 
 ## API
 
-This project provides two cloud functions: `printLabel` and `printBatch`. The former prints a single label, while the latter prints any number of labels.
+This project provides two cloud functions: `printLabel` and `printBatch`. The former prints a single label, while the latter prints any number of different labels.
 
 In the below examples, replace `MY-PROJECT` with the name of your cloud function deployment. The complete URLs for your particular project are printed on the console after a successful deployment (see Installation, above).
 
-### `printLabel`
+### Authentication
+
+The `AUTH_KEY` set during setup must be provided for every request. There are two ways to do this:
+
+1. As a header (preferred). Send the following header with every request:
+    ```
+    Authorization: AUTH_KEY
+    ```
+1. In the JSON body of the request. Set the following key in the JSON request body:
+    ```
+    "authentication": "AUTH_KEY"
+    ```
+
+    For example, the body of the request sent to `printLabel` would look like this:
+    ```json
+    {
+        "authentication": "AUTH_KEY",
+        "body": "Text to print",
+        "qty": 1
+    }
+    ```
+
+### `printLabel` Endpoint
 
 `POST` https://MY-PROJECT.cloudfunctions.net/printLabel
 
 ```json
 {
-    "authentication": "AUTH_KEY",
     "body": "Text to print",
     "qty": 1
 }
@@ -62,13 +88,12 @@ In the below examples, replace `MY-PROJECT` with the name of your cloud function
 
 Returns `200` on success.
 
-### `printBatch`
+### `printBatch` Endpoint
 
 `POST` https://MY-PROJECT.cloudfunctions.net/printBatch
 
 ```json
 {
-    "authentication": "AUTH_KEY",
     "items": [
         {
             "body": "Text to print",

--- a/functions/index.js
+++ b/functions/index.js
@@ -106,7 +106,7 @@ function getParams(body) {
   let qty = 0;
 
   if (body.qtyWord) {
-    qty = wordToNum[body.qtyWord];
+    qty = wordToNum[body.qtyWord.toLowerCase()];
   } else if (body.qty) {
     qty = parseInt(body.qty, 10);
   }

--- a/functions/index.js
+++ b/functions/index.js
@@ -61,8 +61,12 @@ function writeLabel(body, qty) {
  */
 function withAuth(fcn) {
   return function withAuthImpl(req, res) {
-    // Get the pin from the request
-    const secretKey = req.body.authentication;
+    // Get the with token from the request, looking in the body and headers
+    const secretKey = (
+      req.body.authentication ||
+      req.header("authorization") ||
+      ""
+    );
 
     if (!isAuthorized(secretKey)) {
       res.status(401).send("Unauthorized");
@@ -74,15 +78,43 @@ function withAuth(fcn) {
 }
 
 /**
+ * Mapping of number names to integers.
+ *
+ * @type {Object<string, number>}
+ */
+const wordToNum = {
+  "one": 1,
+  "two": 2,
+  "three": 3,
+  "four": 4,
+  "five": 5,
+  "six": 6,
+  "seven": 7,
+  "eight": 8,
+  "nine": 9,
+  "ten": 10,
+};
+
+/**
  * Get label printing parameters from an HTTP Request.
  *
  * @param   {Request.body}  body  Body of an HTTP request.
  *
- * @return  {Object}        Object with keys: qty, body.
+ * @return  {Object}        Object with keys: body, qty?, qtyWord?.
  */
 function getParams(body) {
+  let qty = 0;
+
+  if (body.qtyWord) {
+    qty = wordToNum[body.qtyWord];
+  } else if (body.qty) {
+    qty = parseInt(body.qty, 10);
+  }
+
+  qty = qty || 1;
+
   return {
-    qty: parseInt(body.qty, 10) || 1,
+    qty: qty,
     body: body.body,
   };
 }

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -6,8 +6,8 @@
     "": {
       "name": "functions",
       "dependencies": {
-        "firebase-admin": "^10.1.0",
-        "firebase-functions": "^3.20.1"
+        "firebase-admin": "^10.2.0",
+        "firebase-functions": "^3.21.1"
       },
       "devDependencies": {
         "eslint": "^5.16.0",
@@ -1450,17 +1450,18 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node_modules/firebase-admin": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-10.1.0.tgz",
-      "integrity": "sha512-4i4wu+EFgNfY4+D4DxXkZcmbD832ozUMNvHMkOFQrf8upyp51n6jrDJS+wLok9sd62yeqcImbnsLOympGlISPA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-10.2.0.tgz",
+      "integrity": "sha512-6ehn5J9UEFgi4+naqYvozmGpnZae3cJLdwSkSsDc8/Y0eTBjVMFdf9N2ft7N81UNHA0N5DknOyXhlsdAdyBLCA==",
       "dependencies": {
-        "@firebase/database-compat": "^0.1.1",
-        "@firebase/database-types": "^0.9.3",
+        "@firebase/database-compat": "^0.1.8",
+        "@firebase/database-types": "^0.9.7",
         "@types/node": ">=12.12.47",
         "dicer": "^0.3.0",
         "jsonwebtoken": "^8.5.1",
         "jwks-rsa": "^2.0.2",
-        "node-forge": "^1.3.1"
+        "node-forge": "^1.3.1",
+        "uuid": "^8.3.2"
       },
       "engines": {
         "node": ">=12.7.0"
@@ -1471,9 +1472,9 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "3.20.1",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.20.1.tgz",
-      "integrity": "sha512-x8TEWOsaUnytsNBkrpraa2pOokdjMaGnOkcKdC6HDX/tvlBxrdNpvAMc+Vu/u0lzow9Hs+W+3jEe6Ss4duIz6g==",
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.21.1.tgz",
+      "integrity": "sha512-wUxJaUEceGpCxa+uAYTQUGM13Uc/mekWfJnhuqqPKr8S09WosoVRpoh1yVQO+AnMqNChq3psLkLxHPubW9Tg2A==",
       "dependencies": {
         "@types/cors": "^2.8.5",
         "@types/express": "4.17.3",
@@ -3225,7 +3226,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -4712,25 +4712,26 @@
       }
     },
     "firebase-admin": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-10.1.0.tgz",
-      "integrity": "sha512-4i4wu+EFgNfY4+D4DxXkZcmbD832ozUMNvHMkOFQrf8upyp51n6jrDJS+wLok9sd62yeqcImbnsLOympGlISPA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-10.2.0.tgz",
+      "integrity": "sha512-6ehn5J9UEFgi4+naqYvozmGpnZae3cJLdwSkSsDc8/Y0eTBjVMFdf9N2ft7N81UNHA0N5DknOyXhlsdAdyBLCA==",
       "requires": {
-        "@firebase/database-compat": "^0.1.1",
-        "@firebase/database-types": "^0.9.3",
+        "@firebase/database-compat": "^0.1.8",
+        "@firebase/database-types": "^0.9.7",
         "@google-cloud/firestore": "^4.15.1",
         "@google-cloud/storage": "^5.18.3",
         "@types/node": ">=12.12.47",
         "dicer": "^0.3.0",
         "jsonwebtoken": "^8.5.1",
         "jwks-rsa": "^2.0.2",
-        "node-forge": "^1.3.1"
+        "node-forge": "^1.3.1",
+        "uuid": "^8.3.2"
       }
     },
     "firebase-functions": {
-      "version": "3.20.1",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.20.1.tgz",
-      "integrity": "sha512-x8TEWOsaUnytsNBkrpraa2pOokdjMaGnOkcKdC6HDX/tvlBxrdNpvAMc+Vu/u0lzow9Hs+W+3jEe6Ss4duIz6g==",
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.21.1.tgz",
+      "integrity": "sha512-wUxJaUEceGpCxa+uAYTQUGM13Uc/mekWfJnhuqqPKr8S09WosoVRpoh1yVQO+AnMqNChq3psLkLxHPubW9Tg2A==",
       "requires": {
         "@types/cors": "^2.8.5",
         "@types/express": "4.17.3",
@@ -6106,8 +6107,7 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "optional": true
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "vary": {
       "version": "1.1.2",

--- a/functions/package.json
+++ b/functions/package.json
@@ -13,13 +13,13 @@
     "node": "16"
   },
   "dependencies": {
-    "firebase-admin": "^10.1.0",
-    "firebase-functions": "^3.20.1"
+    "firebase-admin": "^10.2.0",
+    "firebase-functions": "^3.21.1"
   },
   "devDependencies": {
     "eslint": "^5.16.0",
-    "eslint-plugin-promise": "^3.6.0",
-    "eslint-config-google": "^0.14.0"
+    "eslint-config-google": "^0.14.0",
+    "eslint-plugin-promise": "^3.6.0"
   },
   "private": true
 }


### PR DESCRIPTION
Support a new body param, `qtyWord` that accepts the name of a number (e.g. "three").

Also support authorization token provided in a header instead of the body.